### PR TITLE
IE8 Button Bug Fixed for UserIsInAnyGroup condition

### DIFF
--- a/src/main/resources/templates/jira/workflow/condition/userIsInAnyGroups-condition-edit.vm
+++ b/src/main/resources/templates/jira/workflow/condition/userIsInAnyGroups-condition-edit.vm
@@ -65,7 +65,12 @@
 			try {
 				dest.add(newOption, null); // standards compliant; doesn't work in IE
 			} catch(ex) {
-				dest.add(newOption, 0); // IE only
+				try {
+					dest.add(newOption, 0); // IE only
+				} catch(ex) {
+					var newIEOption = new Option(selectedOption.text,selectedOption.value);
+					dest.add(newIEOption); // IE only, second attempt
+				}
 			}
 
 			src.remove(src.selectedIndex);


### PR DESCRIPTION
Hi, 

The fix for this IE8 specific bug was missing in the UserIsInAnyGroup template.

It's nothing much, so I don't think it's enough to be put in the developers information in the pom.xml.

Cheers,

Johann NG
